### PR TITLE
Fix testing config module load path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from . import test_constants as tconst
 @pytest.fixture(scope='module')
 def app():
     app = create_app()
-    app.config.from_object('app.TestConfig')
+    app.config.from_object('app.config.TestConfig')
     context = app.app_context()
     context.push()
     yield app


### PR DESCRIPTION
The testing config module load path was incorrect, and that is why flask-mail was not suppressing send during tests.

In your stackoverflow question you only asserted the `TESTING` config key existed, not that it was equal to `True`.

`assert app.config['TESTING']` is not the same as `assert app.config['TESTING'] == True`